### PR TITLE
Fix problem with cyclical renaming

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ async fn rename_workspace(event: &Box<WindowEvent>, conn: &mut Connection) -> Re
     let current_ws = get_focused_workspace(conn).await?;
     let ws_num = current_ws
         .name
-        .split(": ")
+        .split(":")
         .next()
         .unwrap_or(&current_ws.name);
 


### PR DESCRIPTION
...when `app_id` and `class` is empty. Usual case for Electron apps - happens to me with Slack, VS Code, but also Zoom.

What happens is on each workspace change the workspace name gets extended by another `:`, so after a couple of changes it looks like `9::::`.