### PR TITLE
Fixes #42 - remember workspace name on relayout.

### DIFF
--- a/src/server/message_handler.rs
+++ b/src/server/message_handler.rs
@@ -105,7 +105,7 @@ impl MessageHandler {
                                 );
                                 log::debug!("relayout closure cmd: {}", cmd);
                                 conn.run_command(cmd).await?;
-                                task::sleep(Duration::from_millis(25)).await;
+                                task::sleep(Duration::from_millis(50)).await;
                             }
                             Ok(())
                         },


### PR DESCRIPTION
Also increase wait between window placements. This is because relayout sometimes doesn't result in the expected layout. It's really quite an ugly way to do this but it simplifies other things.