### PR TITLE
Fix missing previously_focused_id

### DIFF
--- a/src/server/event_handlers/misc/window_focus.rs
+++ b/src/server/event_handlers/misc/window_focus.rs
@@ -16,22 +16,32 @@ impl WindowFocus {
         event: Box<WindowEvent>,
         window_focus_cmd: Option<String>,
         window_focus_leave_cmd: Option<String>,
-    ) {
-        if let Ok(mut manager) = Self::new(window_focus_cmd, window_focus_leave_cmd).await {
+        previously_focused_id: Option<i64>,
+    ) -> Option<i64> {
+        if let Ok(mut manager) = Self::new(
+            window_focus_cmd,
+            window_focus_leave_cmd,
+            previously_focused_id,
+        )
+        .await
+        {
             manager.handle(event).await;
+            return manager.previously_focused_id;
         }
+        None
     }
 
     pub async fn new(
         window_focus_cmd: Option<String>,
         window_focus_leave_cmd: Option<String>,
+        previously_focused_id: Option<i64>,
     ) -> Result<Self> {
         let connection = Connection::new().await?;
         Ok(Self {
             connection,
             window_focus_cmd,
             window_focus_leave_cmd,
-            previously_focused_id: None,
+            previously_focused_id,
         })
     }
 

--- a/src/server/message_handler.rs
+++ b/src/server/message_handler.rs
@@ -21,6 +21,7 @@ pub struct MessageHandler {
     workspace_renaming: bool,
     on_window_focus: Option<String>,
     on_window_focus_leave: Option<String>,
+    previously_focused_id: Option<i64>,
 }
 
 impl MessageHandler {
@@ -36,6 +37,7 @@ impl MessageHandler {
             workspace_renaming,
             on_window_focus,
             on_window_focus_leave,
+            previously_focused_id: None,
         }
     }
 
@@ -71,12 +73,16 @@ impl MessageHandler {
         if self.workspace_renaming {
             event_handlers::misc::workspace_renamer::WorkspaceRenamer::handle(event.clone()).await;
         }
-        event_handlers::misc::window_focus::WindowFocus::handle(
+        let previously_focused_id = event_handlers::misc::window_focus::WindowFocus::handle(
             event.clone(),
             self.on_window_focus.clone(),
             self.on_window_focus_leave.clone(),
+            self.previously_focused_id,
         )
         .await;
+        if let Some(previously_focused_id) = previously_focused_id {
+            self.previously_focused_id = Some(previously_focused_id);
+        }
         Ok(())
     }
     pub async fn handle_command(&mut self, cmd: PerswayCommand) -> Result<()> {


### PR DESCRIPTION
Basically, on-window-focus-leave wouldn't actually work. Not sure this is the right way to fix it....